### PR TITLE
Fix version file syntax (missing comma)

### DIFF
--- a/Decalc-o-mania.version
+++ b/Decalc-o-mania.version
@@ -1,23 +1,23 @@
 {
     "NAME": "Decalc'o'mania",
     "URL": "https://raw.githubusercontent.com/Astronants/Decalc-o-Mania/master/Decalc-o-mania.version",
-	"DOWNLOAD": "https://github.com/Astronants/Decalc-o-Mania/releases",
-	"GITHUB": {
+    "DOWNLOAD": "https://github.com/Astronants/Decalc-o-Mania/releases",
+    "GITHUB": {
         "USERNAME": "Astronants",
         "REPOSITORY": "Decalc-o-Mania"
     },
     "VERSION": {
         "MAJOR": 1,
         "MINOR": 0,
-        "PATCH": 0
-		"BUILD": 0
+        "PATCH": 0,
+        "BUILD": 0
     },
     "KSP_VERSION": {
         "MAJOR": 1,
         "MINOR": 4,
         "PATCH": 5
-	},
-	"KSP_VERSION_MIN": {
+    },
+    "KSP_VERSION_MIN": {
         "MAJOR": 1,
         "MINOR": 4,
         "PATCH": 1


### PR DESCRIPTION
While trying to add this mod to CKAN, I found that the .version file is missing a comma, which prevents it from being parsed. This pull request fixes that issue.